### PR TITLE
[Feature]#72 홈 화면의 복사한 링크 저장하기 기능 구현

### DIFF
--- a/app/src/main/java/pokitmons/pokit/MainActivity.kt
+++ b/app/src/main/java/pokitmons/pokit/MainActivity.kt
@@ -1,5 +1,7 @@
 package pokitmons.pokit
 
+import android.content.ClipboardManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -22,6 +24,7 @@ import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import pokitmons.pokit.core.ui.theme.PokitTheme
+import pokitmons.pokit.home.model.ClipboardLinkManager
 import pokitmons.pokit.navigation.RootNavHost
 
 @AndroidEntryPoint
@@ -51,6 +54,25 @@ class MainActivity : ComponentActivity() {
                     currentDestination?.route?.let { route ->
                         // 믹스패널/파베 애널리틱스 화면 이동 로깅용
                     }
+                }
+            }
+        }
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+
+        if (hasFocus) {
+            val clipboardManager = getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+            clipboardManager.primaryClip?.let { clipData ->
+                if (clipData.itemCount == 0) return@let
+                val clipboardTextData = clipData.getItemAt(0).text.toString()
+
+                if (!ClipboardLinkManager.checkUrlIsValid(clipboardTextData)) return@let
+
+                ClipboardLinkManager.setClipboardLink(clipboardTextData)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    clipboardManager.clearPrimaryClip()
                 }
             }
         }

--- a/app/src/main/java/pokitmons/pokit/MainActivity.kt
+++ b/app/src/main/java/pokitmons/pokit/MainActivity.kt
@@ -1,5 +1,6 @@
 package pokitmons.pokit
 
+import android.content.ClipData
 import android.content.ClipboardManager
 import android.os.Build
 import android.os.Bundle
@@ -73,6 +74,9 @@ class MainActivity : ComponentActivity() {
                 ClipboardLinkManager.setClipboardLink(clipboardTextData)
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                     clipboardManager.clearPrimaryClip()
+                } else {
+                    val emptyClip = ClipData.newPlainText("", "")
+                    clipboardManager.setPrimaryClip(emptyClip)
                 }
             }
         }

--- a/app/src/main/java/pokitmons/pokit/navigation/RootDestination.kt
+++ b/app/src/main/java/pokitmons/pokit/navigation/RootDestination.kt
@@ -30,9 +30,14 @@ object Home {
 object AddLink {
     val route: String = "addLink"
     val linkIdArg = "link_id"
-    val routeWithArgs = "$route?$linkIdArg={$linkIdArg}"
+    val linkUrl = "link_url"
+    val routeWithArgs = "$route?$linkIdArg={$linkIdArg}&$linkUrl={${linkUrl}}"
     var arguments = listOf(
         navArgument(linkIdArg) {
+            nullable = true
+            type = NavType.StringType
+        },
+        navArgument(linkUrl) {
             nullable = true
             type = NavType.StringType
         }

--- a/app/src/main/java/pokitmons/pokit/navigation/RootDestination.kt
+++ b/app/src/main/java/pokitmons/pokit/navigation/RootDestination.kt
@@ -31,7 +31,7 @@ object AddLink {
     val route: String = "addLink"
     val linkIdArg = "link_id"
     val linkUrl = "link_url"
-    val routeWithArgs = "$route?$linkIdArg={$linkIdArg}&$linkUrl={${linkUrl}}"
+    val routeWithArgs = "$route?$linkIdArg={$linkIdArg}&$linkUrl={$linkUrl}"
     var arguments = listOf(
         navArgument(linkIdArg) {
             nullable = true

--- a/app/src/main/java/pokitmons/pokit/navigation/RootNavHost.kt
+++ b/app/src/main/java/pokitmons/pokit/navigation/RootNavHost.kt
@@ -1,8 +1,6 @@
 package pokitmons.pokit.navigation
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -91,10 +89,6 @@ fun RootNavHost(
                     }
                 }
             )
-        }
-
-        composable(Home.route) {
-            Box(modifier = Modifier.fillMaxSize())
         }
 
         composable(
@@ -187,7 +181,7 @@ fun RootNavHost(
                         "${PokitDetail.route}/$pokitId?${PokitDetail.pokitCountQuery}=$linkCount"
                     )
                 },
-                onNavigateAddLink = { navHostController.navigate(AddLink.route) },
+                onNavigateAddLink = { navHostController.navigate("${AddLink.route}?${AddLink.linkUrl}=$it") },
                 onNavigateAddPokit = { navHostController.navigate(AddPokit.route) },
                 onNavigateToLinkModify = { navHostController.navigate("${AddLink.route}?${AddLink.linkIdArg}=$it") },
                 onNavigateToPokitModify = { navHostController.navigate("${AddPokit.route}?${AddPokit.pokitIdArg}=$it") },

--- a/core/ui/src/main/java/pokitmons/pokit/core/ui/components/block/pokittoast/PokitToast.kt
+++ b/core/ui/src/main/java/pokitmons/pokit/core/ui/components/block/pokittoast/PokitToast.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import pokitmons.pokit.core.ui.R
 import pokitmons.pokit.core.ui.theme.PokitTheme
@@ -41,6 +42,8 @@ fun PokitToast(
         Text(
             text = text,
             style = PokitTheme.typography.body3Medium.copy(color = PokitTheme.colors.inverseWh),
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f)
         )
 

--- a/feature/addlink/src/main/java/com/strayalpaca/addlink/AddLinkViewModel.kt
+++ b/feature/addlink/src/main/java/com/strayalpaca/addlink/AddLinkViewModel.kt
@@ -85,6 +85,7 @@ class AddLinkViewModel @Inject constructor(
     val memo: StateFlow<String> = _memo.asStateFlow()
 
     val currentLinkId: Int? = savedStateHandle.get<String>("link_id")?.toIntOrNull()
+    private val copiedLinkUrl: String? = savedStateHandle.get<String>("link_url")
 
     // 수정 이전 pokit과 수정 이후 pokit이 다른 경우를 체크하기 위해서만 사용
     private var prevPokitId: Int? = null
@@ -96,6 +97,10 @@ class AddLinkViewModel @Inject constructor(
             loadPokitLink(currentLinkId)
         } else {
             loadUncategorizedPokit()
+        }
+
+        copiedLinkUrl?.let { url ->
+            inputLinkUrl(url)
         }
     }
 

--- a/feature/home/src/main/java/pokitmons/pokit/home/HomeScreen.kt
+++ b/feature/home/src/main/java/pokitmons/pokit/home/HomeScreen.kt
@@ -52,7 +52,7 @@ fun HomeScreen(
     onNavigateToPokitDetail: (String, Int) -> Unit,
     onNavigateToSearch: () -> Unit,
     onNavigateToSetting: () -> Unit,
-    onNavigateAddLink: () -> Unit,
+    onNavigateAddLink: (String?) -> Unit,
     onNavigateAddPokit: () -> Unit,
     onNavigateToLinkModify: (String) -> Unit,
     onNavigateToPokitModify: (String) -> Unit,
@@ -63,6 +63,7 @@ fun HomeScreen(
     var showBottomSheet by remember { mutableStateOf(false) }
 
     val toastMessage by viewModel.toastMessage.collectAsState()
+    val copiedLinkToastMessage by viewModel.copiedLinkUrl.collectAsState()
 
     viewModel.sideEffect.collectAsEffect { homeSideEffect: HomeSideEffect ->
         when (homeSideEffect) {
@@ -102,7 +103,7 @@ fun HomeScreen(
                                 scope.launch {
                                     sheetState.hide()
                                     showBottomSheet = false
-                                    onNavigateAddLink()
+                                    onNavigateAddLink(null)
                                 }
                             },
                         verticalArrangement = Arrangement.Center,
@@ -171,7 +172,7 @@ fun HomeScreen(
                 onNavigateToAlarm = onNavigateToAlarm
             )
             Scaffold(
-                bottomBar = { BottomNavigationBar() }
+                bottomBar = { BottomNavigationBar(viewModel) }
             ) { padding ->
                 Box {
                     when (viewModel.screenType.value) {
@@ -201,6 +202,21 @@ fun HomeScreen(
                                 .padding(start = 12.dp, end = 12.dp, bottom = 48.dp),
                             text = stringResource(id = toastMessageEvent.resourceId),
                             onClickClose = viewModel::closeToastMessage
+                        )
+                    }
+
+                    copiedLinkToastMessage?.linkUrl?.let { linkUrl ->
+                        PokitToast(
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .padding(padding)
+                                .padding(start = 12.dp, end = 12.dp, bottom = 48.dp),
+                            text = stringResource(id = pokitmons.pokit.home.R.string.toast_add_copied_link, linkUrl),
+                            onClickClose = viewModel::closeLinkAddToastMessage,
+                            onClick = {
+                                viewModel.closeLinkAddToastMessage()
+                                onNavigateAddLink(linkUrl)
+                            }
                         )
                     }
                 }

--- a/feature/home/src/main/java/pokitmons/pokit/home/model/ClipboardLinkManager.kt
+++ b/feature/home/src/main/java/pokitmons/pokit/home/model/ClipboardLinkManager.kt
@@ -10,8 +10,8 @@ import java.util.Locale
 import java.util.regex.Pattern
 
 object ClipboardLinkManager {
-    private val _clipboardLinkUrl : MutableEventFlow<String> = MutableEventFlow()
-    val clipboardLinkUrl : EventFlow<String> = _clipboardLinkUrl.asEventFlow()
+    private val _clipboardLinkUrl: MutableEventFlow<String> = MutableEventFlow()
+    val clipboardLinkUrl: EventFlow<String> = _clipboardLinkUrl.asEventFlow()
 
     fun setClipboardLink(linkUrl: String) {
         CoroutineScope(Dispatchers.IO).launch {
@@ -19,9 +19,11 @@ object ClipboardLinkManager {
         }
     }
 
-    fun checkUrlIsValid(url: String) : Boolean {
-        val urlPattern = ("^(http://|https://)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}"
-            + "(:[0-9]{1,5})?(/.*)?$")
+    fun checkUrlIsValid(url: String): Boolean {
+        val urlPattern = (
+            "^(http://|https://)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}" +
+                "(:[0-9]{1,5})?(/.*)?$"
+            )
 
         val pattern = Pattern.compile(urlPattern)
         val matcher = pattern.matcher(url.lowercase(Locale.getDefault()))

--- a/feature/home/src/main/java/pokitmons/pokit/home/model/ClipboardLinkManager.kt
+++ b/feature/home/src/main/java/pokitmons/pokit/home/model/ClipboardLinkManager.kt
@@ -2,16 +2,14 @@ package pokitmons.pokit.home.model
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
-import pokitmons.pokit.core.feature.flow.EventFlow
-import pokitmons.pokit.core.feature.flow.MutableEventFlow
-import pokitmons.pokit.core.feature.flow.asEventFlow
-import java.util.Locale
-import java.util.regex.Pattern
 
 object ClipboardLinkManager {
-    private val _clipboardLinkUrl: MutableEventFlow<String> = MutableEventFlow()
-    val clipboardLinkUrl: EventFlow<String> = _clipboardLinkUrl.asEventFlow()
+    private val _clipboardLinkUrl: MutableSharedFlow<String> = MutableSharedFlow()
+    val clipboardLinkUrl: SharedFlow<String> = _clipboardLinkUrl.asSharedFlow()
 
     fun setClipboardLink(linkUrl: String) {
         CoroutineScope(Dispatchers.IO).launch {
@@ -20,14 +18,7 @@ object ClipboardLinkManager {
     }
 
     fun checkUrlIsValid(url: String): Boolean {
-        val urlPattern = (
-            "^(http://|https://)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}" +
-                "(:[0-9]{1,5})?(/.*)?$"
-            )
-
-        val pattern = Pattern.compile(urlPattern)
-        val matcher = pattern.matcher(url.lowercase(Locale.getDefault()))
-
-        return matcher.matches()
+        val isValidUrl = url.startsWith("http://") || url.startsWith("https://")
+        return isValidUrl
     }
 }

--- a/feature/home/src/main/java/pokitmons/pokit/home/model/ClipboardLinkManager.kt
+++ b/feature/home/src/main/java/pokitmons/pokit/home/model/ClipboardLinkManager.kt
@@ -1,0 +1,31 @@
+package pokitmons.pokit.home.model
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import pokitmons.pokit.core.feature.flow.EventFlow
+import pokitmons.pokit.core.feature.flow.MutableEventFlow
+import pokitmons.pokit.core.feature.flow.asEventFlow
+import java.util.Locale
+import java.util.regex.Pattern
+
+object ClipboardLinkManager {
+    private val _clipboardLinkUrl : MutableEventFlow<String> = MutableEventFlow()
+    val clipboardLinkUrl : EventFlow<String> = _clipboardLinkUrl.asEventFlow()
+
+    fun setClipboardLink(linkUrl: String) {
+        CoroutineScope(Dispatchers.IO).launch {
+            _clipboardLinkUrl.emit(linkUrl)
+        }
+    }
+
+    fun checkUrlIsValid(url: String) : Boolean {
+        val urlPattern = ("^(http://|https://)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}"
+            + "(:[0-9]{1,5})?(/.*)?$")
+
+        val pattern = Pattern.compile(urlPattern)
+        val matcher = pattern.matcher(url.lowercase(Locale.getDefault()))
+
+        return matcher.matches()
+    }
+}

--- a/feature/home/src/main/java/pokitmons/pokit/home/model/LinkAddToastMessage.kt
+++ b/feature/home/src/main/java/pokitmons/pokit/home/model/LinkAddToastMessage.kt
@@ -1,0 +1,3 @@
+package pokitmons.pokit.home.model
+
+data class LinkAddToastMessage(val linkUrl: String)

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name">home</string>
 
     <string name="toast_cannot_create_pokit">최대 30개의 포킷을 생성할 수 있습니다.\n포킷을 삭제한 뒤에 추가해주세요.</string>
+    <string name="toast_add_copied_link">복사한 링크 저장하기\n%s</string>
 </resources>

--- a/feature/login/src/main/java/pokitmons/pokit/login/LoginScreen.kt
+++ b/feature/login/src/main/java/pokitmons/pokit/login/LoginScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -47,19 +48,22 @@ fun LoginScreen(
     val coroutineScope = rememberCoroutineScope()
 
     // TODO 리팩토링
-    when (loginState) {
-        is LoginState.Init -> Unit
-        is LoginState.Login -> {
-            loginViewModel.changeState()
-            onNavigateToTermsOfServiceScreen()
+    LaunchedEffect(loginState) {
+        when (loginState) {
+            is LoginState.Init -> Unit
+            is LoginState.Login -> {
+                loginViewModel.changeState()
+                onNavigateToTermsOfServiceScreen()
+            }
+            is LoginState.Registered -> {
+                loginViewModel.changeState()
+                onNavigateToHomeScreen()
+            }
+            is LoginState.Failed -> loginViewModel.setVisible(true)
+            is LoginState.AutoLogin -> onNavigateToHomeScreen()
         }
-        is LoginState.Registered -> {
-            loginViewModel.changeState()
-            onNavigateToHomeScreen()
-        }
-        is LoginState.Failed -> loginViewModel.setVisible(true)
-        is LoginState.AutoLogin -> onNavigateToHomeScreen()
     }
+
 
     Box(
         modifier = Modifier

--- a/feature/login/src/main/java/pokitmons/pokit/login/LoginScreen.kt
+++ b/feature/login/src/main/java/pokitmons/pokit/login/LoginScreen.kt
@@ -64,7 +64,6 @@ fun LoginScreen(
         }
     }
 
-
     Box(
         modifier = Modifier
             .background(color = PokitTheme.colors.backgroundBase)


### PR DESCRIPTION
## Key Changes
- 링크 복사 후 홈 화면 진입 시 복사한 링크를 바로 추가할 수 있는 Toast UI 표시 구현
- 위 Toast 클릭으로 링크 추가 화면 진입시 복사된 링크로 기본 url를 설정하도록 수정
- 로그인 화면에서 자동로그인시 홈 화면이 2번 호출되는 문제 수정
Resolves: #72 

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## To Reviewers
- 복사한 링크에 대해 Toast UI를 표시하는 대략적인 과정은 아래와 같습니다
1. MainActivity의 onWindowFocusChanged에서 hasFocus가 true일시 clipbaordManager로부터 복사된 링크를 가져온다.
2. 해당 링크가 url 형식에 맞다면, feature:home 모듈 내 새로 정의한 ClipboardLinkManager(싱글톤)의 setClipboardLink를 호출한다.
3. ClipboardLinkManager의 setClipboardLink은 인자로 전달받은 링크 문자열을 MutableEventFlow (SharedFlow 변형)에 emit한다.
4. 이 eventFlow(ClipboardLinkManager.clipboardLinkUrl)은 PokitViewModel 내에서 collect하고 있으며, collect시 HomeScreen에서 이를 감지하여 Toast UI를 표시한다.

코드 분석하면서 호출 과정이 헷갈리거나 조금 더 개선할 수 있는 방향 있다면 알려줘!

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 정해진 코딩 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)

## Etc.
로그인 화면에서 자동 로그인 성공시 홈 화면이 2번 호출되는 현상이 있어서 해당 부분 수정했어!
