### PR TITLE
[Feature] #76 암시적 인텐트를 통한 링크 저장 기능 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,13 +18,19 @@
             android:screenOrientation="portrait"
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:windowSoftInputMode="adjustResize"
-            android:theme="@style/Theme.Pokit">
+            android:theme="@style/Theme.Pokit"
+            android:launchMode="singleInstance"
+            tools:ignore="DiscouragedApi,LockedOrientationActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="text/plain"/>
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/pokitmons/pokit/MainActivity.kt
+++ b/app/src/main/java/pokitmons/pokit/MainActivity.kt
@@ -51,8 +51,9 @@ class MainActivity : ComponentActivity() {
             val currentDestination by remember(navBackStackEntry) { derivedStateOf { navBackStackEntry?.destination } }
 
             viewModel.navigationEvent.collectAsEffect { navigationEvent ->
-                if (navigationEvent is NavigationEvent.AddLink)
+                if (navigationEvent is NavigationEvent.AddLink) {
                     navHostController.navigate("${AddLink.route}?${AddLink.linkUrl}=${navigationEvent.url}")
+                }
             }
 
             PokitTheme {

--- a/app/src/main/java/pokitmons/pokit/MainViewModel.kt
+++ b/app/src/main/java/pokitmons/pokit/MainViewModel.kt
@@ -1,0 +1,56 @@
+package pokitmons.pokit
+
+import android.content.ClipData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import pokitmons.pokit.core.feature.flow.EventFlow
+import pokitmons.pokit.core.feature.flow.MutableEventFlow
+import pokitmons.pokit.core.feature.flow.asEventFlow
+import pokitmons.pokit.home.model.ClipboardLinkManager
+import pokitmons.pokit.home.model.PendingSharedLinkManager
+import pokitmons.pokit.navigation.Login
+import pokitmons.pokit.navigation.ROUTE_WITHOUT_LOGIN
+import javax.inject.Inject
+
+@HiltViewModel
+class MainViewModel @Inject constructor(): ViewModel() {
+    private val _currentRoute: MutableStateFlow<String> = MutableStateFlow(Login.route)
+    val currentRoute : StateFlow<String> = _currentRoute.asStateFlow()
+
+    private val _navigationEvent: MutableEventFlow<NavigationEvent> = MutableEventFlow()
+    val navigationEvent: EventFlow<NavigationEvent> = _navigationEvent.asEventFlow()
+
+    fun setCurrentRoute(route: String) {
+        _currentRoute.update { route }
+    }
+
+    fun setClipData(clipData: ClipData): Boolean {
+        if (clipData.itemCount == 0) return false
+        val clipboardTextData = clipData.getItemAt(0).text.toString()
+
+        if (!ClipboardLinkManager.checkUrlIsValid(clipboardTextData)) return false
+
+        ClipboardLinkManager.setClipboardLink(clipboardTextData)
+        return true
+    }
+
+    fun setSharedLinkUrl(url: String) {
+        if (currentRoute.value in ROUTE_WITHOUT_LOGIN) {
+            PendingSharedLinkManager.setSharedLink(url)
+        } else {
+            viewModelScope.launch {
+                _navigationEvent.emit(NavigationEvent.AddLink(url))
+            }
+        }
+    }
+}
+
+sealed class NavigationEvent {
+    data class AddLink(val url: String): NavigationEvent()
+}

--- a/app/src/main/java/pokitmons/pokit/MainViewModel.kt
+++ b/app/src/main/java/pokitmons/pokit/MainViewModel.kt
@@ -19,9 +19,9 @@ import pokitmons.pokit.navigation.ROUTE_WITHOUT_LOGIN
 import javax.inject.Inject
 
 @HiltViewModel
-class MainViewModel @Inject constructor(): ViewModel() {
+class MainViewModel @Inject constructor() : ViewModel() {
     private val _currentRoute: MutableStateFlow<String> = MutableStateFlow(Login.route)
-    val currentRoute : StateFlow<String> = _currentRoute.asStateFlow()
+    val currentRoute: StateFlow<String> = _currentRoute.asStateFlow()
 
     private val _navigationEvent: MutableEventFlow<NavigationEvent> = MutableEventFlow()
     val navigationEvent: EventFlow<NavigationEvent> = _navigationEvent.asEventFlow()
@@ -52,5 +52,5 @@ class MainViewModel @Inject constructor(): ViewModel() {
 }
 
 sealed class NavigationEvent {
-    data class AddLink(val url: String): NavigationEvent()
+    data class AddLink(val url: String) : NavigationEvent()
 }

--- a/app/src/main/java/pokitmons/pokit/navigation/RootDestination.kt
+++ b/app/src/main/java/pokitmons/pokit/navigation/RootDestination.kt
@@ -3,6 +3,8 @@ package pokitmons.pokit.navigation
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 
+val ROUTE_WITHOUT_LOGIN = listOf(Login.route, TermOfService.route, InputNickname.route, SelectKeyword.route, SignUpSuccess.route)
+
 object Login {
     val route: String = "login"
 }

--- a/app/src/main/java/pokitmons/pokit/navigation/RootNavHost.kt
+++ b/app/src/main/java/pokitmons/pokit/navigation/RootNavHost.kt
@@ -154,7 +154,7 @@ fun RootNavHost(
                 onNavigateToEditNickname = { navHostController.navigate(EditNickname.route) },
                 onNavigateToLogin = {
                     navHostController.navigate(Login.route) {
-                        popUpTo(navHostController.graph.startDestinationId) {
+                        popUpTo(navHostController.graph.id) {
                             inclusive = true
                         }
                     }

--- a/feature/home/src/main/java/pokitmons/pokit/home/HomeScreen.kt
+++ b/feature/home/src/main/java/pokitmons/pokit/home/HomeScreen.kt
@@ -70,6 +70,9 @@ fun HomeScreen(
             HomeSideEffect.NavigateToAddPokit -> {
                 onNavigateAddPokit()
             }
+            is HomeSideEffect.NavigateToAddLink -> {
+                onNavigateAddLink(homeSideEffect.url)
+            }
         }
     }
 

--- a/feature/home/src/main/java/pokitmons/pokit/home/model/HomeSideEffect.kt
+++ b/feature/home/src/main/java/pokitmons/pokit/home/model/HomeSideEffect.kt
@@ -2,5 +2,5 @@ package pokitmons.pokit.home.model
 
 sealed class HomeSideEffect {
     data object NavigateToAddPokit : HomeSideEffect()
-    data class NavigateToAddLink(val url: String): HomeSideEffect()
+    data class NavigateToAddLink(val url: String) : HomeSideEffect()
 }

--- a/feature/home/src/main/java/pokitmons/pokit/home/model/HomeSideEffect.kt
+++ b/feature/home/src/main/java/pokitmons/pokit/home/model/HomeSideEffect.kt
@@ -2,4 +2,5 @@ package pokitmons.pokit.home.model
 
 sealed class HomeSideEffect {
     data object NavigateToAddPokit : HomeSideEffect()
+    data class NavigateToAddLink(val url: String): HomeSideEffect()
 }

--- a/feature/home/src/main/java/pokitmons/pokit/home/model/PendingSharedLinkManager.kt
+++ b/feature/home/src/main/java/pokitmons/pokit/home/model/PendingSharedLinkManager.kt
@@ -1,0 +1,19 @@
+package pokitmons.pokit.home.model
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import pokitmons.pokit.core.feature.flow.EventFlow
+import pokitmons.pokit.core.feature.flow.MutableEventFlow
+import pokitmons.pokit.core.feature.flow.asEventFlow
+
+object PendingSharedLinkManager {
+    private val _sharedLinkUrl: MutableEventFlow<String> = MutableEventFlow()
+    val sharedLinkUrl: EventFlow<String> = _sharedLinkUrl.asEventFlow()
+
+    fun setSharedLink(linkUrl: String) {
+        CoroutineScope(Dispatchers.IO).launch {
+            _sharedLinkUrl.emit(linkUrl)
+        }
+    }
+}

--- a/feature/home/src/main/java/pokitmons/pokit/home/pokit/PokitViewModel.kt
+++ b/feature/home/src/main/java/pokitmons/pokit/home/pokit/PokitViewModel.kt
@@ -34,6 +34,7 @@ import pokitmons.pokit.home.model.ClipboardLinkManager
 import pokitmons.pokit.home.model.HomeSideEffect
 import pokitmons.pokit.home.model.HomeToastMessage
 import pokitmons.pokit.home.model.LinkAddToastMessage
+import pokitmons.pokit.home.model.PendingSharedLinkManager
 import javax.inject.Inject
 import kotlin.math.max
 import com.strayalpaca.pokitdetail.model.Link as DetailLink
@@ -103,6 +104,14 @@ class PokitViewModel @Inject constructor(
         viewModelScope.launch {
             ClipboardLinkManager.clipboardLinkUrl.collectLatest { linkUrl ->
                 _copiedLinkUrlToastMessage.update { LinkAddToastMessage(linkUrl) }
+            }
+        }
+    }
+
+    private fun initPendingSharedLinkUrlDetector() {
+        viewModelScope.launch {
+            PendingSharedLinkManager.sharedLinkUrl.collectLatest { linkUrl ->
+                _sideEffect.emit(HomeSideEffect.NavigateToAddLink(linkUrl))
             }
         }
     }
@@ -239,6 +248,7 @@ class PokitViewModel @Inject constructor(
         initPokitAddEventDetector()
         initLinkRemoveEventDetector()
         initClipboardLinkUrlDetector()
+        initPendingSharedLinkUrlDetector()
 
         loadUnCategoryLinks()
         loadPokits()


### PR DESCRIPTION
## Key Changes
- 타 앱에서 공유하기를 통해 링크를 저장할 수 있는 기능을 구현했습니다.
- 설정-로그아웃을 통해 로그인 화면으로 이동했을 때, 뒤로가기 클릭시 앱이 종료되지 않고 계속 로그인 화면이 반복적으로 표시되는 문제를 수정했습니다.
- MainActivity에서 구현했던 복사된 링크를 처리하는 부분을 MainViewModel로 이동했습니다.

시연 영상 (순서대로 로그인/비로그인)

https://github.com/user-attachments/assets/283257ce-0a82-42c0-b052-b8baa06327e4  

https://github.com/user-attachments/assets/291dce7e-ffbb-4133-a918-fecb73b2609b


Resolves: #76 

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## To Reviewers
- 암시적 링크와 관련된 동작은 아래와 같이 이루어집니다.
  - 로그인이 되어있는 경우
    - 앱 진입(onCreate or onNewIntent)시 바로 링크 추가 화면으로 이동합니다.
  - 로그인이 되어있지 않은 경우
    - PendingSharedLinkManager에 가져온 링크를 저장합니다.
    - 이후 로그인이 완료되어 홈 화면으로 진입했을 때, PendingSharedLinkManager로부터 링크를 가져와 해당 링크에 대한 링크 추가 화면으로 이동합니다.
- 로그인이 되어있는지 여부는 현재 화면이 로그인/회원가입 단계에 속하는지 여부로 판단했습니다.
- 설정 화면에서 로그아웃을 클릭하여 로그인 화면으로 이동했을 때, 뒤로가기 클릭시 계속해서 로그인 화면이 반복적으로 표시되는 문제가 있어 수정했습니다.
  - 해당 문제는 popupTo에 인자로 전달한 id값으로 인한 문제로, popupTo의 경우 현재 backStack에서 id에 해당하는 route를 찾을 수 없다면 popupTo 동작을 무시하고 기본 navigate로 실행됩니다.
  - login화면의 경우 navigation의 startDestination이지만, 홈 화면으로 이동하는 과정에서 pop을 하고 홈 화면으로 이동하므로 backStack에는 존재하지 않게 됩니다. 이로 인해서 backStack에서 startDestinationId에 해당하는 route를 찾지 못해 popupTo 동작이 정상적으로 수행되지 않았습니다.
  - 위 문제는 startDestinationId 부분을 0으로 변경함으로써 (navBackStack을 살펴본 결과, root는 항상 0값을 가짐을 확인했습니다.) 수정했습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 정해진 코딩 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)

## Etc.
암시적 링크 처리하는 부분에 대해서 가독성이나 조금 더 개선할 부분이 있다면 피드백 부탁해!
